### PR TITLE
fix: graph rendering too wide when heading title is too long (#812)

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -34,6 +34,7 @@ export const stylesApex: CSSResultGroup = css`
   #header {
     padding: 8px 16px 0px;
     grid-area: header;
+    overflow: hidden;
   }
   #header.floating {
     position: absolute;


### PR DESCRIPTION
The graph would previously render at the max width of either the card or the header, which if the header was too wide for the display would mean part of the graph would render outside of the card